### PR TITLE
Fix nil map assignment error

### DIFF
--- a/social.go
+++ b/social.go
@@ -341,7 +341,7 @@ func (call *GetFriendshipStatusCall) WithContext(ctx context.Context) *GetFriend
 
 // Do method
 func (call *GetFriendshipStatusCall) Do() (*GetFriendshipStatusResponse, error) {
-	var urlQuery url.Values
+	urlQuery := url.Values{}
 	urlQuery.Set("access_token", call.accessToken)
 	res, err := call.c.getHeaderAuth(call.ctx, APIEndpointGetFriendshipStratus, urlQuery)
 	if res != nil && res.Body != nil {


### PR DESCRIPTION
In the `GetFriendshipStatusCall.Do` method, there is a bug that causes a runtime panic with the error message "assignment to entry in nil map". This error occurs when trying to set a value in the `urlQuery` map, which has been declared but not initialized.

Here is the problematic code:

```go
func (call *GetFriendshipStatusCall) Do() (*GetFriendshipStatusResponse, error) {
	var urlQuery url.Values
	urlQuery.Set("access_token", call.accessToken)
	...
}
```

