### PR TITLE
fix: fix posible os.exit(1) and improve logging

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.23
 
     - name: Build
       run: go build -v ./...

--- a/client.go
+++ b/client.go
@@ -27,7 +27,6 @@ const (
 type Client struct {
 	channelID     string
 	channelSecret string
-	channelToken  string
 	endpointBase  *url.URL     // default APIEndpointBase
 	httpClient    *http.Client // default http.DefaultClient
 }
@@ -123,13 +122,5 @@ func (client *Client) post(ctx context.Context, endpoint string, body io.Reader)
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	return client.do(ctx, req)
-}
-
-func (client *Client) delete(ctx context.Context, endpoint string) (*http.Response, error) {
-	req, err := http.NewRequest("DELETE", client.url(endpoint), nil)
-	if err != nil {
-		return nil, err
-	}
 	return client.do(ctx, req)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kkdai/line-login-sdk-go
 
-go 1.13
+go 1.23

--- a/response.go
+++ b/response.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 )
@@ -165,15 +164,13 @@ type TokenResponse struct {
 func (t TokenResponse) DecodePayload(channelID string) (*BasicPayload, error) {
 	splitToken := strings.Split(t.IDToken, ".")
 	if len(splitToken) != 3 {
-		log.Println("Error: idToken size is wrong, size=", len(splitToken))
-		return nil, fmt.Errorf("error: idToken size is wrong")
+		return nil, fmt.Errorf("idToken size is wrong")
 	}
 
 	payloadSegment := splitToken[1]
 	decodedPayload, err := b64.RawURLEncoding.DecodeString(payloadSegment)
 	if err != nil {
-		log.Println("base64url decode error:", err)
-		return nil, fmt.Errorf("error: base64url decode")
+		return nil, fmt.Errorf("base64url decode error: %w", err)
 	}
 
 	retPayload := &BasicPayload{}
@@ -198,20 +195,18 @@ func (t TokenResponse) DecodePayload(channelID string) (*BasicPayload, error) {
 func (t TokenResponse) DecodeLineProfilePlusPayload(channelID string) (*LineProfilePlusPayload, error) {
 	splitToken := strings.Split(t.IDToken, ".")
 	if len(splitToken) < 3 {
-		log.Println("Error: idToken size is wrong, size=", len(splitToken))
-		return nil, fmt.Errorf("Error: idToken size is wrong.")
+		return nil, fmt.Errorf("idToken size is wrong")
 	}
 
 	payloadSegment := splitToken[1]
 	decodedPayload, err := b64.RawURLEncoding.DecodeString(payloadSegment)
 	if err != nil {
-		log.Println("base64url decode error:", err)
-		return nil, fmt.Errorf("error: base64url decode")
+		return nil, fmt.Errorf("base64url decode error: %w", err)
 	}
 
 	retPayload := &LineProfilePlusPayload{}
 	if err := json.Unmarshal(decodedPayload, retPayload); err != nil {
-		return nil, fmt.Errorf("json unmarshal error: %v", err)
+		return nil, fmt.Errorf("json unmarshal error: %w", err)
 	}
 
 	if retPayload.Iss != "https://access.line.me" {
@@ -252,18 +247,6 @@ func decodeToBasicResponse(res *http.Response) (*BasicResponse, error) {
 		if err == io.EOF {
 			return &result, nil
 		}
-		return nil, err
-	}
-	return &result, nil
-}
-
-func decodeToUserProfileResponse(res *http.Response) (*UserProfileResponse, error) {
-	if err := checkResponse(res); err != nil {
-		return nil, err
-	}
-	decoder := json.NewDecoder(res.Body)
-	result := UserProfileResponse{}
-	if err := decoder.Decode(&result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/social.go
+++ b/social.go
@@ -2,10 +2,8 @@ package social
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"strings"
 )
@@ -64,17 +62,15 @@ func (call *GetAccessTokenCall) Do() (*TokenResponse, error) {
 }
 
 // GetWebLoinURL - LINE LOGIN 2.1 get LINE Login  authorization request URL
-func (client *Client) GetWebLoinURL(redirectURL string, state string, scope string, options AuthRequestOptions) string {
+func (client *Client) GetWebLoinURL(redirectURL string, state string, scope string, options AuthRequestOptions) (string, error) {
 	u, err := url.Parse(APIEndpointAuthBase)
 	if err != nil {
-		log.Print(err)
-		os.Exit(1)
+		return "", err
 	}
 	u.Path = path.Join(u.Path, APIEndpointAuthorize)
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
-		log.Print(err)
-		os.Exit(1)
+		return "", err
 	}
 	q := req.URL.Query()
 	q.Add("response_type", "code")
@@ -100,21 +96,19 @@ func (client *Client) GetWebLoinURL(redirectURL string, state string, scope stri
 	}
 
 	req.URL.RawQuery = q.Encode()
-	return req.URL.String()
+	return req.URL.String(), nil
 }
 
 // GetPKCEWebLoinURL - LINE LOGIN 2.1 get LINE Login authorization request URL by PKCE
-func (client *Client) GetPKCEWebLoinURL(redirectURL string, state string, scope string, codeChallenge string, options AuthRequestOptions) string {
+func (client *Client) GetPKCEWebLoinURL(redirectURL string, state string, scope string, codeChallenge string, options AuthRequestOptions) (string, error) {
 	u, err := url.Parse(APIEndpointAuthBase)
 	if err != nil {
-		log.Print(err)
-		os.Exit(1)
+		return "", err
 	}
 	u.Path = path.Join(u.Path, APIEndpointAuthorize)
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
-		log.Print(err)
-		os.Exit(1)
+		return "", err
 	}
 	q := req.URL.Query()
 	q.Add("response_type", "code")
@@ -142,7 +136,7 @@ func (client *Client) GetPKCEWebLoinURL(redirectURL string, state string, scope 
 	}
 
 	req.URL.RawQuery = q.Encode()
-	return req.URL.String()
+	return req.URL.String(), nil
 }
 
 // TokenVerify: Verifies the access token.
@@ -172,8 +166,7 @@ func (call *TokenVerifyCall) WithContext(ctx context.Context) *TokenVerifyCall {
 func (call *TokenVerifyCall) Do() (*TokenVerifyResponse, error) {
 	u, err := url.Parse(APIEndpointBase)
 	if err != nil {
-		log.Print(err)
-		os.Exit(1)
+		return nil, err
 	}
 	u.Path = path.Join(u.Path, APIEndpointTokenVerify)
 	req, err := http.NewRequest("GET", u.String(), nil)

--- a/social_test.go
+++ b/social_test.go
@@ -17,7 +17,7 @@ var (
 	userID       string
 )
 
-//Provide those data for testing.
+// Provide those data for testing
 func init() {
 	accessToken = os.Getenv("LINE_ACCESS_TOKEN")
 	refreshToken = os.Getenv("LINE_REFRESH_TOKEN")
@@ -49,7 +49,7 @@ func TestGetAccessToken(t *testing.T) {
 		t.Errorf("err: %v", err)
 	}
 
-	t.Logf(" data:= %v", ret)
+	t.Logf(" data:= %+v", ret)
 }
 
 func TestGetUserProfile(t *testing.T) {
@@ -68,11 +68,23 @@ func TestGetURLCode(t *testing.T) {
 	checkEnvVariables(t)
 
 	scope := "profile openid" //profile | openid | email
-	state := GenerateNonce()
-	nonce := GenerateNonce()
+	state, err := GenerateNonce()
+	if err != nil {
+		t.Errorf("GenerateNonce Error: %v", err)
+		return
+	}
+	nonce, err := GenerateNonce()
+	if err != nil {
+		t.Errorf("GenerateNonce Error: %v", err)
+		return
+	}
 
 	client, _ := New(cID, cSecret)
-	url := client.GetWebLoinURL(qURL, state, scope, AuthRequestOptions{Nonce: nonce, BotPrompt: "normal", Prompt: "consent"})
+	url, err := client.GetWebLoinURL(qURL, state, scope, AuthRequestOptions{Nonce: nonce, BotPrompt: "normal", Prompt: "consent"})
+	if err != nil {
+		t.Errorf("err: %v", err)
+		return
+	}
 	log.Println("url: ", url)
 }
 
@@ -80,14 +92,30 @@ func TestPKCEGetURLCode(t *testing.T) {
 	checkEnvVariables(t)
 
 	scope := "profile openid" //profile | openid | email
-	state := GenerateNonce()
-	nonce := GenerateNonce()
+	state, err := GenerateNonce()
+	if err != nil {
+		t.Errorf("GenerateNonce Error: %v", err)
+		return
+	}
+	nonce, err := GenerateNonce()
+	if err != nil {
+		t.Errorf("GenerateNonce Error: %v", err)
+		return
+	}
 
-	codeVer := GenerateCodeVerifier(43)
+	codeVer, err := GenerateCodeVerifier(43)
+	if err != nil {
+		t.Errorf("GenerateCodeVerifier Error: %v", err)
+		return
+	}
 	codeChallenge := PkceChallenge(codeVer)
 
 	client, _ := New(cID, cSecret)
-	url := client.GetPKCEWebLoinURL(qURL, state, scope, codeChallenge, AuthRequestOptions{Nonce: nonce, BotPrompt: "normal", Prompt: "consent"})
+	url, err := client.GetPKCEWebLoinURL(qURL, state, scope, codeChallenge, AuthRequestOptions{Nonce: nonce, BotPrompt: "normal", Prompt: "consent"})
+	if err != nil {
+		t.Errorf("err: %v", err)
+		return
+	}
 	log.Println("url: ", url)
 }
 
@@ -130,7 +158,11 @@ func TestRevokeToken(t *testing.T) {
 func TestVerifyIDToken(t *testing.T) {
 	checkEnvVariables(t)
 
-	nonce := GenerateNonce()
+	nonce, err := GenerateNonce()
+	if err != nil {
+		t.Errorf("GenerateNonce Error: %v", err)
+		return
+	}
 
 	client, _ := New(cID, cSecret)
 	ret, err := client.VerifyIDToken(iDToken, VerifyIDTokenRequestOptions{
@@ -147,7 +179,11 @@ func TestVerifyIDToken(t *testing.T) {
 func TestGetAccessTokenPKCE(t *testing.T) {
 	checkEnvVariables(t)
 
-	codeVer := GenerateCodeVerifier(43)
+	codeVer, err := GenerateCodeVerifier(43)
+	if err != nil {
+		t.Errorf("GenerateCodeVerifier Error: %v", err)
+		return
+	}
 
 	if len(code) == 0 {
 		t.Skip("Skip it since don't exist LINE login code.")
@@ -159,5 +195,5 @@ func TestGetAccessTokenPKCE(t *testing.T) {
 		t.Errorf("err: %v", err)
 	}
 
-	t.Logf(" data:= %v", ret)
+	t.Logf(" data:= %+v", ret)
 }

--- a/tool_test.go
+++ b/tool_test.go
@@ -17,7 +17,11 @@ func TestCodeChallenge(t *testing.T) {
 
 func TestCodeVerifier(t *testing.T) {
 
-	cv1 := GenerateCodeVerifier(0)
+	cv1, err := GenerateCodeVerifier(0)
+	if err != nil {
+		t.Errorf("GenerateCodeVerifier Error: %v", err)
+		return
+	}
 	if len(cv1) != 43 {
 		t.Errorf("CodeVerifier Error: \ncodeVer=%s\n", cv1)
 	}


### PR DESCRIPTION
Changes:
* Replaced `math/rand` with `crypto/rand` to enhance cryptographic security.
* Removed a potential `os.Exit(1)` that could cause unexpected termination.
* Cleaned up logging output for better readability.
* Updated `Go` version to a currently maintained and supported release.

Breaking Changes:
* `GetWebLoinURL` and `GetPKCEWebLoinURL` may return an error

To ensure the tests pass, I had to run them in separate processes because `LINE_LOGIN_CODE` could only be used once and cannot be reused across multiple tests.
I'm not entirely sure if this approach aligns with best practices, so feel free to adjust or improve it as needed.